### PR TITLE
remove bodyparser and mongoose.Promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@babel/preset-env": "^7.5.5",
     "@hapi/joi": "^15.1.1",
     "bcryptjs": "^2.4.3",
-    "body-parser": "^1.19.0",
     "compression": "^1.7.4",
     "cors": "^2.8.5",
     "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@babel/polyfill": "^7.4.4",
     "@babel/preset-env": "^7.5.5",
     "@hapi/joi": "^15.1.1",
-    "bcryptjs": "^2.4.3",
+    "bcrypt": "^3.0.6",
     "compression": "^1.7.4",
     "cors": "^2.8.5",
     "debug": "^4.1.1",

--- a/server/app.js
+++ b/server/app.js
@@ -3,7 +3,7 @@ import morgan from 'morgan';
 import debug from 'debug';
 import cors from 'cors';
 import mongoose from 'mongoose';
-import bodyParser from 'body-parser';
+// import bodyParser from 'body-parser'; DEPRECATED
 import compression from 'compression';
 import { config } from 'dotenv';
 import Response from './utils/Response';
@@ -12,14 +12,19 @@ import Response from './utils/Response';
 config();
 
 const app = express();
-const port = process.env.PORT || 6000;
+const port = process.env.PORT || 5000;
 const debugged = debug('server');
 
 app.use(morgan('dev'));
 app.use(cors());
 app.use(compression());
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: false }));
+
+// DEPRECATED
+// app.use(bodyParser.json());
+// app.use(bodyParser.urlencoded({ extended: false }));
+
+app.use(express.json());
+app.use(express.urlencoded({ extended: false }));
 
 app.get('/', (req, res) => Response.success(res, 200, 'Bears team 10!'));
 
@@ -38,9 +43,15 @@ app.use((req, res, next) => {
   next();
 });
 
-mongoose.Promise = global.Promise;
-mongoose.set('useNewUrlParser', true);
+// DEPRECATED
+// mongoose.Promise = global.Promise; //
+
+// DUPLICATED
+// mongoose.set('useNewUrlParser', true);
+
 mongoose.set('useFindAndModify', false);
+
+// should be disabled in production
 mongoose.set('useCreateIndex', true);
 mongoose.connect(process.env.DB_URI, { useNewUrlParser: true });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -906,10 +906,13 @@ basic-auth@~2.0.0:
   dependencies:
     safe-buffer "5.1.2"
 
-bcryptjs@^2.4.3:
-  version "2.4.3"
-  resolved "https://registry.yarnpkg.com/bcryptjs/-/bcryptjs-2.4.3.tgz#9ab5627b93e60621ff7cdac5da9733027df1d0cb"
-  integrity sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms=
+bcrypt@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/bcrypt/-/bcrypt-3.0.6.tgz#f607846df62d27e60d5e795612c4f67d70206eb2"
+  integrity sha512-taA5bCTfXe7FUjKroKky9EXpdhkVvhE5owfxfLYodbrAR1Ul3juLmIQmIQBK4L9a5BuUcE6cqmwT+Da20lF9tg==
+  dependencies:
+    nan "2.13.2"
+    node-pre-gyp "0.12.0"
 
 binary-extensions@^1.0.0:
   version "1.13.1"
@@ -2823,6 +2826,11 @@ mute-stream@0.0.7:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
+nan@2.13.2:
+  version "2.13.2"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.13.2.tgz#f51dc7ae66ba7d5d55e1e6d4d8092e802c9aefe7"
+  integrity sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==
+
 nan@^2.12.1:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
@@ -2882,7 +2890,7 @@ node-modules-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
-node-pre-gyp@^0.12.0:
+node-pre-gyp@0.12.0, node-pre-gyp@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz#39ba4bb1439da030295f899e3b520b7785766149"
   integrity sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -921,7 +921,7 @@ bluebird@3.5.1:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
   integrity sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==
 
-body-parser@1.19.0, body-parser@^1.19.0:
+body-parser@1.19.0:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
   integrity sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==


### PR DESCRIPTION
I removed body-parser and use native express middleware instead included in express 4.16 and above.
I removed the call to mongoose.Promise. DEPRECATED. 
Mongoose 5.0 and above use native promises by default
I removed the use of useNewUrlParser property